### PR TITLE
Updated ApiEnabledAudit to inject a query comment.

### DIFF
--- a/src/Audit/ApiEnabledAudit.php
+++ b/src/Audit/ApiEnabledAudit.php
@@ -37,6 +37,10 @@ abstract class ApiEnabledAudit extends Audit {
 
   protected function search(Sandbox $sandbox, $query)
   {
+    // Inject a query comment that uniquely identifies this query
+    // for performance monitoring purposes.
+    $query = "// Drutiny:" . $sandbox->getPolicy()->get('name') . "\n" . $query;
+    
     $steps = $sandbox->getReportingPeriodSteps();
     switch (TRUE) {
       case $steps >= 86400:


### PR DESCRIPTION
The query comment can be used to uniquely identify a query that was executed through Sumologic's Search API. This can be helpful for performance monitoring purposes.