### PR TITLE
Fix query escaping in LogMatchPolicyRouter.php

### DIFF
--- a/src/Audit/LogMatchPolicyRouter.php
+++ b/src/Audit/LogMatchPolicyRouter.php
@@ -78,6 +78,14 @@ class LogMatchPolicyRouter extends AbstractAnalysis
     }
 
     /**
+     * Extract start of string up to wildcard for Sumo matching
+     */
+    protected function queryTruncateToWildcard($search_phrase) {
+        $search_escaped_quotes = $this->queryEscapeQuotes($search_phrase);
+        return preg_replace('/\*.*$/', '', $search_escaped_quotes);
+    }
+
+    /**
      * Surround query string with asterisks for matching, avoiding double quotes
      * and escaping quotes.
      */
@@ -96,7 +104,7 @@ class LogMatchPolicyRouter extends AbstractAnalysis
         $query = $this->interpolate($query_key);
         $keywords = [];
         foreach ($this->queries[$query_key] as $search_phrase) {
-            $keywords[] = sprintf(' "%s"', $this->queryEscapeQuotes($search_phrase));
+            $keywords[] = sprintf(' "%s"', $this->queryTruncateToWildcard($search_phrase));
         }
         $query .= ' ( '.implode(' or ', $keywords) . ' )'.PHP_EOL;
         $query .= '| "" as policy_match'.PHP_EOL;

--- a/src/Audit/LogMatchPolicyRouter.php
+++ b/src/Audit/LogMatchPolicyRouter.php
@@ -35,7 +35,7 @@ class LogMatchPolicyRouter extends AbstractAnalysis
      */
     public function configure():void
     {
-        
+
         $this->addParameter(
             'query',
             AuditInterface::PARAMETER_REQUIRED,
@@ -46,7 +46,7 @@ class LogMatchPolicyRouter extends AbstractAnalysis
             AuditInterface::PARAMETER_REQUIRED,
             'The search field to check matches a given search phrase',
         );
-        
+
         $this->addParameter(
             'search_phrase',
             AuditInterface::PARAMETER_REQUIRED,
@@ -71,6 +71,23 @@ class LogMatchPolicyRouter extends AbstractAnalysis
     }
 
     /**
+     * Prepare string to be within double-quoted Sumo query string.
+     */
+    protected function queryEscapeQuotes($search_phrase) {
+        return str_replace('"', '\"', $search_phrase);
+    }
+
+    /**
+     * Surround query string with asterisks for matching, avoiding double quotes
+     * and escaping quotes.
+     */
+    protected function queryAsteriskAndEscapeQuotes($search_phrase) {
+        $search_escaped_quotes = $this->queryEscapeQuotes($search_phrase);
+        return preg_replace("/\\*\\**/", "*", "*{$search_escaped_quotes}*");
+    }
+
+
+    /**
      * {@inheritdoc}
      */
     protected function gather(Sandbox $sandbox)
@@ -79,13 +96,17 @@ class LogMatchPolicyRouter extends AbstractAnalysis
         $query = $this->interpolate($query_key);
         $keywords = [];
         foreach ($this->queries[$query_key] as $search_phrase) {
-            $keywords[] = sprintf(' "%s"', addslashes($search_phrase));
+            $keywords[] = sprintf(' "%s"', $this->queryEscapeQuotes($search_phrase));
         }
         $query .= ' ( '.implode(' or ', $keywords) . ' )'.PHP_EOL;
         $query .= '| "" as policy_match'.PHP_EOL;
         $field = $this->getParameter('search_field');
         foreach ($this->queries[$query_key] as $policy => $search_phrase) {
-            $query .= sprintf('| if ('.$field.' matches "*%s*", "%s", policy_match) as policy_match', addslashes($search_phrase), $policy).PHP_EOL;
+            $query .= sprintf(
+                '| if ('.$field.' matches "%s", "%s", policy_match) as policy_match',
+                $this->queryAsteriskAndEscapeQuotes($search_phrase),
+                $policy
+            ) . PHP_EOL;
         }
         $query .= '| count, first('.$field.') as first_match by policy_match, ' . $this->getParameter('group_by');
 


### PR DESCRIPTION
Various bugs in LogMatchPolicyRouter.php  ... the queries aren't properly escaped, double asterisks can happen for some queries that include asterisks (the Sumo search would break). 

Example:

if query in the policy is:

```
parameters:
  query: '{source_index} namespace={namespace}.php-errors'
  search_phrase: 'class ''Drupal*memcache*Lock*MemcacheLockFactory'' does not have a method ''getPersistent'''
... snip ...
```

Original output before patch. Note the bad escaping of `'` characters:

```
_sourceName=Polaris namespace=mlcc.php-errors (  ...SNIP... or  "class \'Drupal*memcache*Lock*MemcacheLockFactory\' does not have a method \'getPersistent\'" or   ...SNIP...)
.. SNIP ...
| if (log matches "*Class \'Drupal*memcache*DrupalMemcacheConfig\' not found*", "PhpErrors:SumoLogic:Check4", policy_match) as policy_match
... SNIP ...
```

New output: note the first line's query is just `class 'Drupal` because at this point Sumo doesn't like wildcards: 

```
_sourceName=Polaris namespace=mlcc.php-errors (  ...SNIP... or  "class 'Drupal" or   ...SNIP...)
.. SNIP ...
| if (log matches "*Class 'Drupal*memcache*DrupalMemcacheConfig' not found*", "PhpErrors:SumoLogic:Check4", policy_match) as policy_match
... SNIP ...
```

The other fix is for the `matches` queries' asterisk-surrounding mechanism:

* If query was `exited on signal 11 *SIGSEGV*`  (note the final asterisk)
* The asterisk-surrounded one would be `*exited on signal 11 *SIGSEGV**` (note the double final asterisk)
* After fix, query is now `*exited on signal 11 *SIGSEGV*`
