### PR TITLE
Add a new job status that's being returned by Sumo

### DIFF
--- a/src/JobStatus.php
+++ b/src/JobStatus.php
@@ -19,6 +19,7 @@ enum JobStatus {
             'GATHERING RESULTS'	                => JobStatus::JOB_IN_PROGRESS,
             'GATHERING RESULTS FROM SUBQUERIES' => JobStatus::JOB_IN_PROGRESS,
             'DONE GATHERING RESULTS'	        => JobStatus::COMPLETE,
+            'DONE GATHERING HISTOGRAM'          => JobStatus::COMPLETE,
             'CANCELED'	                        => JobStatus::JOB_CANCELLED,
             default => throw new RuntimeException("So such status: $status")
         };


### PR DESCRIPTION
The sumo api is now returning DONE GATHERING HISTOGRAM as a valid response when a job has completed. Adding the new status to the JobStatus map.